### PR TITLE
Link now points to your master repository

### DIFF
--- a/Project/Podfile.lock
+++ b/Project/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - objc-zmq (0.1.0)
+  - objc-zmq (0.1.1)
 
 DEPENDENCIES:
   - objc-zmq (from `../objc-zmq.podspec`)
@@ -9,6 +9,6 @@ EXTERNAL SOURCES:
     :path: ../objc-zmq.podspec
 
 SPEC CHECKSUMS:
-  objc-zmq: 355ff86aa9ee72c3021f01828d98bca4ea4013f2
+  objc-zmq: 7d5502abf900810924f62ec3f5ad6bbde99a6bf0
 
 COCOAPODS: 0.29.0

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ objc-zmq is not yet available through [CocoaPods](http://cocoapods.org).
 
 To install it simply add the following line to your Podfile:
 
-	pod "objc-zmq" :git => 'https://github.com/neoneye/objc-zmq.git'
+	pod "objc-zmq" :git => 'https://github.com/jeremy-w/objc-zmq.git'
 
 ## License
 

--- a/objc-zmq.podspec
+++ b/objc-zmq.podspec
@@ -1,17 +1,17 @@
 Pod::Spec.new do |s|
   s.name         = "objc-zmq"
-  s.version      = "0.1.0"
+  s.version      = "0.1.1"
   s.summary      = "Objective-C binding for ZeroMQ"
   s.description  = <<-DESC
     Bundled with ZeroMQ 4.0.3 library.
     
     This is an Objective-C version of the reference ZeroMQ object-oriented C API. It follows the guidelines laid out by the official "Guidelines for ZeroMQ bindings".
     DESC
-  s.homepage     = "https://github.com/neoneye/objc-zmq"
+  s.homepage     = "https://github.com/jeremy-w/objc-zmq"
   s.screenshots  = "www.example.com/screenshots_1", "www.example.com/screenshots_2"
   s.license      = 'MIT'
   s.author       = { "Simon Strandgaard" => "simon@opcoders.com" }
-  s.source       = { :git => "https://github.com/neoneye/objc-zmq.git", :tag => s.version.to_s }
+  s.source       = { :git => "https://github.com/jeremy-w/objc-zmq.git", :tag => s.version.to_s }
   s.platform     = :osx, '10.9'
   s.osx.deployment_target = '10.9'
   s.requires_arc = true


### PR DESCRIPTION
Hi Jeremy

Here is a tiny pull request.
It fixes the links so they now point to your github repository.

Can you tag the repository after you have merged?
The tag should be named "0.1.1"
This is necessary for cocoapods to properly work.

Cheers
