### PR TITLE
Fix CocoaPods instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ objc-zmq is not yet available through [CocoaPods](http://cocoapods.org).
 
 To install it simply add the following line to your Podfile:
 
-	pod "objc-zmq" :git => 'https://github.com/jeremy-w/objc-zmq.git'
+	pod "objc-zmq", :git => 'https://github.com/jeremy-w/objc-zmq.git'
 
 ## License
 


### PR DESCRIPTION
Without the comma (,) CocoaPods complains with a syntax error
